### PR TITLE
Using a single node for everything, shasta-like

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,18 @@ __A docker image exposing a full node, a solidity node and an event server, i.e.
 
 ## Usage
 
-Run it with:
+If you are using TronBox 2.1.9+ and are setting just a `fullHost` in `tronbox.js` run
+
+```
+docker run -it \
+  -p 9090:9090 \
+  --rm \
+  --name tron \
+  trontools/quickstart
+```
+Notice the `--rm` option which will delete the container when you stop it.
+
+With TronBox < 2.1.9, run instead:
 ```
 docker run -it \
   -p 8091:8091 \
@@ -15,8 +26,6 @@ docker run -it \
   --name tron \
   trontools/quickstart
 ```
-
-Notice the `--rm` option which will delete the container when you stop it.
 
 If you need to expose different ports to avoid conflicts, for example the ports 9090, 9091 and 9092, you can set up them when you run the container, like in this example:
 ```
@@ -73,6 +82,22 @@ module.exports = {
       fullNode: "http://127.0.0.1:8090",
       solidityNode: "http://127.0.0.1:8091",
       eventServer: "http://127.0.0.1:8092",
+      network_id: "*"
+    }
+  }
+};
+
+```
+
+In TronBox 2.1.9+ you can just set a `fullHost` like in:
+```
+module.exports = {
+  networks: {
+    development: {
+      privateKey: 'da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0',
+      consume_user_resource_percent: 30,
+      fee_limit: 100000000,
+      fullHost: "http://127.0.0.1:9090",
       network_id: "*"
     }
   }
@@ -254,6 +279,6 @@ Sometimes, for example running tests with TronBox, we ask the node to performe a
 
 Unfortunately, you cannot use this image to create a node in the main Tron network because it uses a version of java-tron who is not the one required for a standard full node.
 
-### Latest version is `1.1.15`
+### Latest version is `1.1.16`
 
 To be updated, take a look at https://hub.docker.com/r/trontools/quickstart/tags/

--- a/app/index.js
+++ b/app/index.js
@@ -116,9 +116,54 @@ setApp('FULL-NODE', 18190, 8090)
 setApp('SOLIDITY-NODE', 18191, 8091)
 setApp('EVENT-SERVER', 18891, 8092)
 
+
+const conf = {
+  changeOrigin: true,
+  onProxyReq,
+  onError
+}
+
+const app = express();
+app.use(morgan(only()))
+app.use(bodyParser.json())
+
+app.use('/wallet', proxy({
+  ...conf,
+  onProxyRes: setHeaders('FULL-NODE'),
+  target: 'http://127.0.0.1:18190'
+}));
+
+app.use('/favicon.ico', function (req, res) {
+  res.send('')
+})
+
+app.use('/admin', admin)
+
+app.use('/walletsolidity', proxy({
+  ...conf,
+  onProxyRes: setHeaders('SOLIDITY-NODE'),
+  target: 'http://127.0.0.1:18191'
+}));
+
+app.use('/walletextension', proxy({
+  ...conf,
+  onProxyRes: setHeaders('SOLIDITY-NODE'),
+  target: 'http://127.0.0.1:18191'
+}));
+
+app.use('/', proxy({
+  ...conf,
+  onProxyRes: setHeaders('EVENT-SERVER'),
+  target: 'http://127.0.0.1:18891'
+}));
+
+app.listen(9090);
+
+
 const n = "\n"
 
-console.log(n, 'Full Node listening on', chalk.bold('http://127.0.0.1:8090'),
-    n, 'Solidity Node listening on', chalk.bold('http://127.0.0.1:8091'),
-    n, 'Event Server listening on', chalk.bold('http://127.0.0.1:8092'), n)
+console.log(n, 'fullNode listening on', chalk.bold('http://127.0.0.1:8090'),
+    n, 'solidityNode listening on', chalk.bold('http://127.0.0.1:8091'),
+    n, 'eventServer listening on', chalk.bold('http://127.0.0.1:8092'),
+    n, 'fullHost listening on', chalk.bold('http://127.0.0.1:9090'), n)
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tron-proxy",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tron-proxy",
-  "version": "1.1.15",
+  "version": "1.1.16",
   "description": "A minimalist proxy for a Tron private network",
   "main": "index.js",
   "repository": "https://github.com/tronprotocol/docker-tron-quickstart",

--- a/utils/run-mononode.sh
+++ b/utils/run-mononode.sh
@@ -4,9 +4,6 @@ docker rm -f tron
 
 docker run -it \
   --rm \
-  -p 8090:8090 \
-  -p 8091:8091 \
-  -p 8092:8092 \
   -p 9090:9090 \
   -e "defaultBalance=100000" \
   -e "showQueryString=true" \


### PR DESCRIPTION
@tmao1129 This version simplifies the configuration in `tronbox.js`. It requires TronBox 2.1.9 (or newer).